### PR TITLE
avoiding RuntimeException

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -80,7 +80,7 @@ return [
 
 	'key' => env('APP_KEY', 'SomeRandomString'),
 
-	'cipher' => 'AES-256-CBC',
+	'cipher' => 'AES-128-CBC',
 
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
while upgrading to 5.5 changed to AES-128-CBC
`The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.`